### PR TITLE
Use Terraform Cloud

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ on:
         description: The Terraform Cloud hostname.
         type: string
         required: false
-        default: terraform.takescoop.com
+        default: app.terraform.io
       tflint_version:
         description: The version of TFLint that will be used.
         type: string


### PR DESCRIPTION
Switch the default host to Terraform Cloud. Will be a new major version. Requires a corresponding `terraform_token` for Cloud.