### PR TITLE
Pin Terraform Version to 1.1.8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,9 @@ on:
         description: The version of Terraform that will be used.
         type: string
         required: false
-        default: latest
+        # Default set to 1.1.8 (our current workspace version) pending a fix to our incompatible Terraform modules in 1.2.0
+        # https://takescoop.atlassian.net/browse/PLATFORM-2435
+        default: 1.1.8
       terraform_hostname:
         description: The Terraform Cloud hostname.
         type: string


### PR DESCRIPTION
Pins our Terraform version to 1.1.8 (which is what we are currently running for workspaces in Terraform Cloud). Once we get a chance to identify and fix the issues with our modules, we can revert this back to latest

https://takescoop.atlassian.net/browse/PLATFORM-2435
https://takescoop.slack.com/archives/CPSE3T7C2/p1652914253773559