### PR TITLE
Pin tflint 0.38.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,8 @@ on:
         description: The version of TFLint that will be used.
         type: string
         required: false
-        default: latest
+        # TODO: Set to latest after 0.39.0 bug resolution https://github.com/terraform-linters/tflint/issues/1450
+        default: v0.38.1
       tflint_config_version:
         description: The version of TFLint config from https://github.com/takescoop/tflint-config that will be used.
         type: string


### PR DESCRIPTION
PR pins tflint to 0.38.1 and adds a note regarding when to revert back to "latest"

There is a [bug ](https://github.com/terraform-linters/tflint/issues/1450) in the tflint 0.39.0 release causing [issues](https://github.com/TakeScoop/kubernetes/runs/7545604087?check_suite_focus=true) in some repos.