### PR TITLE
test: use matrix with reusable workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,12 @@ on:
     branches:
       - master
 jobs:
-  valid:
+  test:
+    strategy:
+      matrix:
+        fixture:
+          - valid
+          - configuration-alias
     uses: ./.github/workflows/check.yml
     with:
-      working_directory: ./test/valid
-  configuration-alias:
-    uses: ./.github/workflows/check.yml
-    with:
-      working_directory: ./test/configuration-alias
+      working_directory: ./test/${{ matrix.fixture }}


### PR DESCRIPTION
DRYs up the tests for this workflow repo, taking advantage of newly added support for invoking reusable workflows from matrix jobs:

https://github.blog/changelog/2022-08-22-github-actions-improvements-to-reusable-workflows-2/

Previously, reusable workflows could not be called from matrix jobs and so the test workflow was split into 2 job definitions.